### PR TITLE
replace fetch-h2, add error handling and make motion polling configurable

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -55,6 +55,13 @@
                 "placeholder": "45",
                 "description": "Camera status does not update live and must be fetched periodically. By default this is done every 45 seconds"
             },
+            "camera-motion-polling-seconds": {
+                "title": "Camera Motion Polling (seconds)",
+                "type": "integer",
+                "minimum": 0,
+                "placeholder": "20",
+                "description": "Camera motion detection does not update live and must be fetched periodically. By default this is done every 20 seconds"
+            },
             "enable-verbose-logging": {
                 "title": "Enable Verbose Logging",
                 "default": false,
@@ -84,7 +91,7 @@
         { "key": "pin", "placeholder": "2FA pin", "notitle": true },
         { "type": "section", "title": "Advanced Settings", "expandable": true, "expanded": false,
             "items": ["hide-privacy-switch", "enable-liveview", "avoid-thumbnail-battery-drain", "camera-thumbnail-refresh-seconds",
-                      "camera-status-polling-seconds", "enable-verbose-logging", "enable-debug-logging", "enable-startup-diagnostic"]
+                      "camera-status-polling-seconds", "camera-motion-polling-seconds", "enable-verbose-logging", "enable-debug-logging", "enable-startup-diagnostic"]
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dependencies": {
         "@homebridge/camera-utils": "^1.3.0",
         "commander": "^6.2.0",
-        "fetch-h2": "^2.5.1",
+        "@adobe/helix-fetch": "^1.9.2",
         "ffmpeg-for-homebridge": "0.0.9"
     },
     "devDependencies": {

--- a/src/blink-api.js
+++ b/src/blink-api.js
@@ -1,6 +1,6 @@
 const crypto = require("crypto");
 // const fetch = require('node-fetch');
-const { fetch } = require( 'fetch-h2' );
+const { fetch } = require( '@adobe/helix-fetch' );
 const http = require('http');
 const https = require('https');
 const {sleep} = require('./utils');
@@ -574,8 +574,8 @@ class BlinkAPI {
      *   ]
      * }
      **/
-    async getMediaChange(maxTTL = 60, after = "1970-01-01T00:00:01+0000", page = 1) {
-        return await this.get(`/api/v1/accounts/{accountID}/media/changed?since=1970-01-01T00:00:01+0000&page=1`, maxTTL);
+    async getMediaChange(maxTTL = 60, after = "2021-02-01T00:00:01+0000", page = 1) {
+        return await this.get(`/api/v1/accounts/{accountID}/media/changed?since=2021-02-01T00:00:01+0000&page=1`, maxTTL);
     }
 
     async deleteMedia(medialist = []) {

--- a/src/blink.js
+++ b/src/blink.js
@@ -716,7 +716,9 @@ class Blink {
         return await this.blinkAPI.getCameraStatus(networkID, cameraID, maxTTL);
     }
     async getCameraLastMotion(networkID, cameraID = null) {
-        const res = await this.blinkAPI.getMediaChange(MOTION_POLL);
+        const motionConfig = this.config["camera-motion-polling-seconds"];
+        const motionPoll = motionConfig === 0 ? 0 : motionConfig || MOTION_POLL;
+        const res = await this.blinkAPI.getMediaChange(motionPoll);
         const media = (res.media || [])
             .filter(m => !networkID || m.network_id === networkID)
             .filter(m => !cameraID || m.device_id === cameraID)

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,12 @@ class HomebridgeBlink {
         }
 
         // await this.blink.refreshCameraThumbnail();
-        await this.blink.refreshData();
+	    try {
+            await this.blink.refreshData();
+	    }
+	    catch (err) {
+		    this.log.error(err)
+	    }
         this.timerID = setInterval(intervalPoll, BLINK_STATUS_EVENT_LOOP * 1000);
     }
 


### PR DESCRIPTION
Hi, firstly thanks for the great plugin! I have been running a few fixes locally for a few weeks, would be great if they could be merged into the main version of the plugin.

1. fetch-h2 has some known issues fixed in the adobe fetch fork (see here https://github.com/adobe/helix-fetch/issues/103).
Note since this there is a v2 of adobe fetch which is a complete re-write. This change uses v1 the fixed fork of fetch-h2.

2. Add error handling to the poller. If there is a network issue it kills the poller so add a simple try catch to prevent this.

3. Make motion poller time configurable, I found 20s too high.

Thanks
David