### PR TITLE
Blink Mini enabled/disabled fix

### DIFF
--- a/src/blink-api.js
+++ b/src/blink-api.js
@@ -1052,17 +1052,11 @@ class BlinkAPI {
         return await this.deleteMedia(clipID);
     }
 
-    async enableCameraMotion(networkID, cameraID, model) {
-        if (model === 'owl') {
-            return await this.updateOwlSettings(networkID, cameraID, { enabled: true });
-        }
+    async enableCameraMotion(networkID, cameraID) {
         return await this.post(`/network/${networkID}/camera/${cameraID}/enable`);
     }
 
-    async disableCameraMotion(networkID, cameraID, model) {
-        if (model === 'owl') {
-            return await this.updateOwlSettings(networkID, cameraID, { enabled: false });
-        }
+    async disableCameraMotion(networkID, cameraID) {
         return await this.post(`/network/${networkID}/camera/${cameraID}/disable`);
     }
 

--- a/src/blink-api.js
+++ b/src/blink-api.js
@@ -1052,11 +1052,17 @@ class BlinkAPI {
         return await this.deleteMedia(clipID);
     }
 
-    async enableCameraMotion(networkID, cameraID) {
+    async enableCameraMotion(networkID, cameraID, model) {
+        if (model === 'owl') {
+            return await this.updateOwlSettings(networkID, cameraID, { enabled: true });
+        }
         return await this.post(`/network/${networkID}/camera/${cameraID}/enable`);
     }
 
-    async disableCameraMotion(networkID, cameraID) {
+    async disableCameraMotion(networkID, cameraID, model) {
+        if (model === 'owl') {
+            return await this.updateOwlSettings(networkID, cameraID, { enabled: false });
+        }
         return await this.post(`/network/${networkID}/camera/${cameraID}/disable`);
     }
 

--- a/src/blink.js
+++ b/src/blink.js
@@ -100,7 +100,7 @@ class BlinkDevice {
             this.log(`${desc} for ${this.name} is: ${disp}`);
         };
 
-        const setCallback = async (val, callback) => {            
+        const setCallback = async (val, callback) => {
             await Promise.resolve(setFunc.bind(this)(val))
                 .then(res => callback(null, res))
                 .catch(err => this.log.error(err) && callback(err));
@@ -777,7 +777,6 @@ class Blink {
         else {
             await this._command(async () => await this.blinkAPI.disableCameraMotion(networkID, cameraID, model));
         }
-    
         await this.refreshData(true);
     }
 

--- a/src/blink.js
+++ b/src/blink.js
@@ -100,7 +100,7 @@ class BlinkDevice {
             this.log(`${desc} for ${this.name} is: ${disp}`);
         };
 
-        const setCallback = async (val, callback) => {
+        const setCallback = async (val, callback) => {            
             await Promise.resolve(setFunc.bind(this)(val))
                 .then(res => callback(null, res))
                 .catch(err => this.log.error(err) && callback(err));
@@ -421,7 +421,7 @@ class BlinkCamera extends BlinkDevice {
 
     async setEnabled(target = true) {
         if (this.enabled !== Boolean(target)) {
-            await this.blink.setCameraMotionSensorState(this.networkID, this.cameraID, target);
+            await this.blink.setCameraMotionSensorState(this.networkID, this.cameraID, target, this.model);
         }
     }
 
@@ -770,13 +770,14 @@ class Blink {
         await this.refreshData(true);
     }
 
-    async setCameraMotionSensorState(networkID, cameraID, enabled = true) {
+    async setCameraMotionSensorState(networkID, cameraID, enabled = true, model) {
         if (enabled) {
-            await this._command(async () => await this.blinkAPI.enableCameraMotion(networkID, cameraID));
+            await this._command(async () => await this.blinkAPI.enableCameraMotion(networkID, cameraID, model));
         }
         else {
-            await this._command(async () => await this.blinkAPI.disableCameraMotion(networkID, cameraID));
+            await this._command(async () => await this.blinkAPI.disableCameraMotion(networkID, cameraID, model));
         }
+    
         await this.refreshData(true);
     }
 

--- a/src/blink.js
+++ b/src/blink.js
@@ -363,8 +363,7 @@ class BlinkCamera extends BlinkDevice {
     }
 
     isCameraMini(model) {
-        if (model === 'owl') return true;
-        return false;
+        return model === 'owl';
     }
 
     getTemperature() {


### PR DESCRIPTION
Fixes #30 

After inspecting the traffic when enabling the Blink mini devices, I noticed it had a completely different API route than the others. Turns out it's the same endpoint as the one used in a function that already exists `updateOwlSettings`.

Passing in `{ enabled: true/false }` as the body, instead of a different endpoint for each.

I debugged the plugin and all works as expected, but as I haven't spent any time in the codebase, let me know if there is an easier way to get the model in `blink-api` without having to pass it around.